### PR TITLE
User/dashboard

### DIFF
--- a/app/controllers/users/discover_controller.rb
+++ b/app/controllers/users/discover_controller.rb
@@ -1,0 +1,5 @@
+class Users::DiscoverController < ApplicationController
+  def index
+
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,5 @@
+class UsersController < ApplicationController
+  def show
+    @user = User.find(params[:id])
+  end
+end

--- a/app/views/users/_viewing_party.html.erb
+++ b/app/views/users/_viewing_party.html.erb
@@ -1,0 +1,19 @@
+<div id="#{party_type}_#{viewing_party.id}">
+<p>Movie Title: <%= link_to viewing_party.movie.title, movie_path(viewing_party.movie) %></p>
+<p><%= viewing_party.movie.image %></p>
+<p>Date of Event: <%= viewing_party.date %></p>
+<p>Start Time: <%= viewing_party.start_time %></p>
+<% if @user == viewing_party.host %>
+  <p>Host: <%= viewing_party.host %></p>
+<% else %>
+  <p>You are the host of this viewing party.</p>
+<% end %>
+<p>Invited: </p>
+<% viewing_party.users.each do |user| %>
+  <% if @user.name == user.name  %>
+    <b><%= user.name %></b>
+  <% else %>
+    <%= user.name %>
+  <% end %>
+<% end %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,8 @@
+<h1><%= @user.name %>'s Dashboard</h1>
+<%= button_to 'Discover Movies', discover_user_path(@user), method: :get %>
+<div id="hosted_parties">
+  <%= render partial: "viewing_party", collection: @user.hosted_parties, locals: {party_type: "hosted" } || "You are not hosting any viewing parties." %>
+</div>
+<div id="invited_parties">
+  <%= render partial: "viewing_party", collection: @user.invited_parties, locals: {party_type: "invited"} || "You have no upcoming viewing parties." %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  resources :users
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  resources :users
+  resources :users do
+    member do
+      get 'discover', to: 'users/discover#index'
+    end
+  end
 end

--- a/spec/factories/viewing_parties.rb
+++ b/spec/factories/viewing_parties.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     duration { "" }
     date { "2023-01-30 19:47:54" }
     start_time { "2023-01-30 19:47:54" }
-    movie { nil }
+    movie_id { nil }
+    host { create(:user) }
   end
 end

--- a/spec/factories/viewing_party_users.rb
+++ b/spec/factories/viewing_party_users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :viewing_party_user do
-    user { nil }
-    viewing_party { nil }
+    user { create(:user) }
+    viewing_party { create(:viewing_party) }
   end
 end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'The User show page', type: :feature do
     end
 
     describe 'viewing parties' do
-      it 'lists all viewing parties the user has been invited to with their data' do
+      xit 'lists all viewing parties the user has been invited to with their data' do
         invited_parties = user.invited_parties
         #TODO: Some tests will fail until API decisions are made
         within "#invited_parties" do
@@ -47,7 +47,7 @@ RSpec.describe 'The User show page', type: :feature do
         end
       end
 
-      it 'lists all viewing parties the user has hosted' do
+      xit 'lists all viewing parties the user has hosted' do
         hosted_parties = user.hosted_parties
         #TODO: Some tests will fail until API decisions are made
         within "hosted_parties" do

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe 'The User show page', type: :feature do
               expect(page).to have_content "Start Time: #{party.start_time}"
               expect(page).to have_content "Host: #{party.host.name}"
               expect(page).to have_content "Invited: #{party.invited}"
-              expect(page).to have_content "Invited: #{party.invited}"
               page.html.should include("<b>#{user.name}</b>")
             end
           end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'The User show page', type: :feature do
+  describe 'the user show page' do
+
+    let!(:user) { create(:user) }
+
+    before :each do
+      visit user_path(user)
+    end
+
+    it 'displays the users name in the title' do
+      expect(page).to have_content "#{user.name} Dashboard"
+    end
+
+    it 'has a button to Discover Movies' do
+      expect(page).to have_button "Discover Movies" 
+    end
+
+    describe 'viewing parties' do
+      xit 'displays each viewing parties data' do
+         
+      end
+
+      xit 'lists all viewing parties the user has been invited to' do
+
+      end
+
+      xit 'lists all viewing parties the user has hosted' do
+
+      end
+    end
+  end
+end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -4,30 +4,66 @@ RSpec.describe 'The User show page', type: :feature do
   describe 'the user show page' do
 
     let!(:user) { create(:user) }
+    let!(:invited_party1) { create(:viewing_party) }
+    let!(:invited_party2) { create(:viewing_party) }
+    let!(:hosted_party1) { create(:viewing_party, host: user) }
+    let!(:hosted_party2) { create(:viewing_party, host: user) }
+    let!(:vpu1){ create(:viewing_party_user, user: user, viewing_party: invited_party1) }
+    let!(:vpu2){ create(:viewing_party_user, user: user, viewing_party: invited_party2) }
 
     before :each do
       visit user_path(user)
     end
 
     it 'displays the users name in the title' do
-      expect(page).to have_content "#{user.name} Dashboard"
+      expect(page).to have_content "#{user.name}'s Dashboard"
     end
 
     it 'has a button to Discover Movies' do
       expect(page).to have_button "Discover Movies" 
+
+      click_button "Discover Movies"
+
+      expect(current_path).to eq discover_user_path(user)
     end
 
     describe 'viewing parties' do
-      xit 'displays each viewing parties data' do
-         
+      it 'lists all viewing parties the user has been invited to with their data' do
+        invited_parties = user.invited_parties
+        #TODO: Some tests will fail until API decisions are made
+        within "#invited_parties" do
+          invited_parties.each do |party|
+            within "invited_#{party.id}" do
+              expect(page).to have_content "Movie Title: #{party.movie.title}"
+              expect(page).to have_link "#{party.movie.title}"
+              expect(page.find('#movie-image')['src']).to have_content 'Movie_Image.' 
+              expect(page).to have_content "Date of Event: #{party.date}"
+              expect(page).to have_content "Start Time: #{party.start_time}"
+              expect(page).to have_content "Host: #{party.host.name}"
+              expect(page).to have_content "Invited: #{party.invited}"
+              expect(page).to have_content "Invited: #{party.invited}"
+              page.html.should include("<b>#{user.name}</b>")
+            end
+          end
+        end
       end
 
-      xit 'lists all viewing parties the user has been invited to' do
-
-      end
-
-      xit 'lists all viewing parties the user has hosted' do
-
+      it 'lists all viewing parties the user has hosted' do
+        hosted_parties = user.hosted_parties
+        #TODO: Some tests will fail until API decisions are made
+        within "hosted_parties" do
+          hosted_parties.each do |party|
+            within "hosted_#{party.id}" do
+              expect(page).to have_content "You are the host of this viewing party."
+              expect(page).to have_content "Movie Title: #{party.movie.title}"
+              expect(page).to have_link "#{party.movie.title}"
+              expect(page.find('#movie-image')['src']).to have_content 'Movie_Image.' 
+              expect(page).to have_content "Date of Event: #{party.date}"
+              expect(page).to have_content "Start Time: #{party.start_time}"
+              expect(page).to have_content "Invited: #{party.invited}"
+            end
+          end
+        end
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,7 +12,7 @@ require File.expand_path('../config/environment', __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
-
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,6 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+  config.after do
+    FactoryBot.rewind_sequences
+  end
+end


### PR DESCRIPTION
###Issue number, if any: 
  Completes 'User Dashboard Page' Card
  Completes 'Dashboard:Discover Movies' Card 
  Begins 'User Dashboard Page'

###Summary of what changed and why: 

Adds User dashboard page, which displays the user name, a button to go to the discover page.
Adds a discover page.

On the 'User Dashboard Page' card, it said 
 "*more instructions on this in the Dashboard:Discover Movies issue.
 **more instructions on this in the Dashboard:Viewing Parties issue."
 So I started to complete the 'Dashboard:Viewing Parties' card as well. 
This card depends on having a 'movie' object, so I have set up the tests and the view page,
but currently those tests are broken and you cannot view the dashboard page. 
I could spend some time stubbing some responses from the movie object 
or leave it broken and add TODO tags.


###Known Issues: 
Failing tests, movie undefined for Vparty model object.

###Reviewers: 
@KelsiePorter 