### PR TITLE
Null movie

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   has_many :hosted_parties, :class_name => "ViewingParty", foreign_key: "host_id" 
   has_many :viewing_party_users
-  has_many :invited_parties, through: :viewing_party_users, :source => :user
+  has_many :invited_parties, through: :viewing_party_users, :source => :viewing_party
 
   validates_presence_of :name
   validates :email, uniqueness: true, presence: true

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -2,4 +2,8 @@ class ViewingParty < ApplicationRecord
   belongs_to :host, :class_name => "User" 
   has_many :viewing_party_users
   has_many :users, through: :viewing_party_users
+
+  def movie
+    NullMovie.new
+  end
 end

--- a/app/services/null_movie.rb
+++ b/app/services/null_movie.rb
@@ -1,0 +1,13 @@
+class NullMovie
+  def title
+    'Title'
+  end
+
+  def image
+    'image'
+  end
+
+  def id
+    1
+  end
+end

--- a/app/views/users/_viewing_party.html.erb
+++ b/app/views/users/_viewing_party.html.erb
@@ -1,8 +1,9 @@
 <div id="#{party_type}_#{viewing_party.id}">
-<p>Movie Title: <%= link_to viewing_party.movie.title, movie_path(viewing_party.movie) %></p>
+<p>Movie Title:  </p>
 <p><%= viewing_party.movie.image %></p>
 <p>Date of Event: <%= viewing_party.date %></p>
 <p>Start Time: <%= viewing_party.start_time %></p>
+<% binding.pry %>
 <% if @user == viewing_party.host %>
   <p>Host: <%= viewing_party.host %></p>
 <% else %>

--- a/app/views/users/_viewing_party.html.erb
+++ b/app/views/users/_viewing_party.html.erb
@@ -1,9 +1,8 @@
 <div id="#{party_type}_#{viewing_party.id}">
-<p>Movie Title:  </p>
+<p>Movie Title: <%= link_to viewing_party.movie.title, movie_path(viewing_party.movie) %></p>
 <p><%= viewing_party.movie.image %></p>
 <p>Date of Event: <%= viewing_party.date %></p>
 <p>Start Time: <%= viewing_party.start_time %></p>
-<% binding.pry %>
 <% if @user == viewing_party.host %>
   <p>Host: <%= viewing_party.host %></p>
 <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,6 @@ Rails.application.routes.draw do
       get 'discover', to: 'users/discover#index'
     end
   end
+
+  resources :movies, only: [:show]
 end

--- a/spec/models/viewing_party_spec.rb
+++ b/spec/models/viewing_party_spec.rb
@@ -6,4 +6,11 @@ RSpec.describe ViewingParty, type: :model do
     it { should have_many :viewing_party_users }
     it { should have_many(:users).through(:viewing_party_users) }
   end
+
+  describe '#movie' do
+    it 'returns a movie object' do
+      vp = create(:viewing_party)
+      expect(vp.movie).to be_a NullMovie
+    end
+  end
 end


### PR DESCRIPTION
###Issue number, if any: 
  None

###Summary of what changed and why: 
Temp fix to failing tests/broken show page, adds a NullMovie object so that show page can display.
Also fixes a problem with user relation; invited_parties was returning a list of users that were invited instead of parties that this user had been invited to.

###Known Issues:
NullMovie can still be used in the future, allows us to have a kind of default response if the API query fails for some reason.

###Reviewers: @KelsiePorter 