### PR TITLE
New viewing party page

### DIFF
--- a/app/controllers/users/viewing_parties_controller.rb
+++ b/app/controllers/users/viewing_parties_controller.rb
@@ -1,5 +1,18 @@
 class Users::ViewingPartiesController < ApplicationController
   def new
+    @host = User.find(params[:user_id])
+    @movie = MovieFacade.new(params[:movie_id]).movie
+    @viewing_party = ViewingParty.new
+  end
 
+  private
+
+  def viewing_party_params
+    params.require(:viewing_party)
+          .permit(
+            :duration, 
+            :date, 
+            :start_time
+          )
   end
 end

--- a/app/controllers/users/viewing_parties_controller.rb
+++ b/app/controllers/users/viewing_parties_controller.rb
@@ -3,6 +3,11 @@ class Users::ViewingPartiesController < ApplicationController
     @host = User.find(params[:user_id])
     @movie = MovieFacade.new(params[:movie_id]).movie
     @viewing_party = ViewingParty.new
+    @all_users = User.where.not(id: @host)
+  end
+
+  def create 
+    require 'pry'; binding.pry
   end
 
   private

--- a/app/controllers/users/viewing_parties_controller.rb
+++ b/app/controllers/users/viewing_parties_controller.rb
@@ -1,23 +1,67 @@
 class Users::ViewingPartiesController < ApplicationController
+  before_action :load_host
+  before_action :load_movie
+  before_action :validate_duration, only: [:create]
+
   def new
-    @host = User.find(params[:user_id])
-    @movie = MovieFacade.new(params[:movie_id]).movie
-    @viewing_party = ViewingParty.new
     @all_users = User.where.not(id: @host)
   end
 
-  def create 
-    require 'pry'; binding.pry
+  def create
+    viewing_party = ViewingParty.new(viewing_party_params)
+
+    if viewing_party.save
+      viewing_party_user_ids.each do |user_id|
+        viewing_party.users << User.find(user_id)
+      end
+
+      redirect_to user_path(@host.id)
+    else
+      redirect_to new_user_movie_viewing_party_path(@host.id, @movie.id)
+
+      flash[:alert] = viewing_party.errors.full_messages.to_sentence
+    end
   end
 
   private
 
+  def load_host
+    @host ||= User.find(params[:user_id])
+  end
+
+  def load_movie
+    @movie ||= MovieFacade.new(params[:movie_id]).movie
+  end
+
+  def validate_duration
+    if viewing_party_params[:duration].to_i < @movie.runtime
+      flash[:alert] = "Viewing Party duration must be greater than or equal to movie runtime which is #{@movie.runtime}"
+      redirect_to new_user_movie_viewing_party_path(@host.id, @movie.id)
+    end
+  end
+
+  def date
+    "#{params["date(1i)"]}/#{params["date(2i)"]}/#{params["date(3i)"]}"
+  end
+
+  def time 
+    "#{params["start_time(4i)"]}:#{params["start_time(5i)"]}:00"
+  end
+
   def viewing_party_params
-    params.require(:viewing_party)
-          .permit(
+    params.permit(
             :duration, 
-            :date, 
-            :start_time
-          )
+            :host_id,
+            :movie_id
+    ).merge(
+      date: date, 
+      start_time: "#{date} #{time}"
+    )
+  end
+
+  def viewing_party_user_ids
+    string_ids = params.permit(user_ids: [])[:user_ids]
+    string_ids.shift 
+    string_ids.map {|id| id.to_i}
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
   end
 
   def create
-   user = User.new(permitted_params)
+    user = User.new(permitted_params)
    
     if user.save 
       redirect_to user_path(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,8 @@ class User < ApplicationRecord
 
   validates_presence_of :name
   validates :email, uniqueness: true, presence: true
+
+  def display_name 
+    "#{name} (#{email})"
+  end
 end

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -8,10 +8,8 @@ class ViewingParty < ApplicationRecord
                        :start_time,
                        :movie_id
 
-  #placeholder movie method
   def movie
     movie ||= MovieFacade.new(movie_id).movie
   end
-
 end
 

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -3,8 +3,15 @@ class ViewingParty < ApplicationRecord
   has_many :viewing_party_users
   has_many :users, through: :viewing_party_users
 
+  validates_presence_of :duration,
+                       :date,
+                       :start_time,
+                       :movie_id
+
+  #placeholder movie method
   def movie
     movie ||= MovieFacade.new(movie_id).movie
   end
+
 end
 

--- a/app/services/movie_service.rb
+++ b/app/services/movie_service.rb
@@ -1,7 +1,7 @@
 class MovieService 
 
-  def initialize(url = '')
-    @url = url
+  def initialize(movie_id = '')
+    @movie_id = movie_id
   end
 
   def get_top_movies
@@ -19,9 +19,9 @@ class MovieService
   end
 
   def movie
-   movie_params = JSON.parse(service.get("/3/movie/#{@url}").body, symbolize_names: true)
-   movie_params = movie_params.merge(JSON.parse(service.get("/3/movie/#{@url}/credits").body, symbolize_names: true))
-   movie_params = movie_params.merge(JSON.parse(service.get("/3/movie/#{@url}/reviews").body, symbolize_names: true))
+   movie_params = JSON.parse(service.get("/3/movie/#{@movie_id}").body, symbolize_names: true)
+   movie_params = movie_params.merge(JSON.parse(service.get("/3/movie/#{@movie_id}/credits").body, symbolize_names: true))
+   movie_params = movie_params.merge(JSON.parse(service.get("/3/movie/#{@movie_id}/reviews").body, symbolize_names: true))
   end
 
   private

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,7 +2,7 @@
 
 <center>
   <section>
-    <%= form_with model: @user, url: "/users", method: :post do |f| %>
+    <%= form_with model: @user, url: "/users", method: :post, local: true do |f| %>
       <%= f.label :name %>
       <%= f.text_field :name %>
       <br>

--- a/app/views/users/viewing_parties/new.html.erb
+++ b/app/views/users/viewing_parties/new.html.erb
@@ -5,3 +5,21 @@
   <%= button_to "Discover Page", discover_user_path(@host), method: :get %>
 </center>
 
+<center>
+  <section class="new_viewing_party_form">
+    <%= form_with model: @viewing_party, url: user_movie_viewing_parties_path(@host.id, @movie.id), method: :post do |f| %>
+      <%= f.label :duration, "Duration of Party" %>
+      <%= f.text_field :duration %>
+      <br>
+      <%= f.label :date, "Day" %>
+      <%= f.date_select :date %>
+      <br>
+      <%= f.label :start_time, "Start Time" %>
+      <%= f.time_select :start_time %>
+      <br>
+      <%= f.collection_check_boxes(:user_ids, @all_users, :id, :display_name) %>
+      <br>
+      <%= f.submit 'Create Party' %>
+    <% end %>
+  </section>
+</center>

--- a/app/views/users/viewing_parties/new.html.erb
+++ b/app/views/users/viewing_parties/new.html.erb
@@ -7,7 +7,11 @@
 
 <center>
   <section class="new_viewing_party_form">
-    <%= form_with model: @viewing_party, url: user_movie_viewing_parties_path(@host.id, @movie.id), method: :post do |f| %>
+    <%= form_with url: user_movie_viewing_parties_path(@host.id, @movie.id), method: :post, local: true do |f| %>
+      <%= f.hidden_field :host_id, value: @host.id %>
+      <%= f.label :movie, "Movie Title" %>
+      <%= f.text_field :movie, value: @movie.title, disabled: true %>
+      <br>
       <%= f.label :duration, "Duration of Party" %>
       <%= f.text_field :duration %>
       <br>

--- a/app/views/users/viewing_parties/new.html.erb
+++ b/app/views/users/viewing_parties/new.html.erb
@@ -1,0 +1,7 @@
+<center>
+  Create a Movie Party for <%= @movie.title %>
+</center>
+<center>
+  <%= button_to "Discover Page", discover_user_path(@host), method: :get %>
+</center>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
       get 'discover', to: 'users/discover#index'
     end
     resources :movies, only: [:index, :show], controller: 'users/movies' do
-      resources :viewing_parties, only: [:new], controller: 'users/viewing_parties'
+      resources :viewing_parties, only: [:new, :create], controller: 'users/viewing_parties'
     end
   end
 end

--- a/spec/factories/viewing_parties.rb
+++ b/spec/factories/viewing_parties.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :viewing_party do
-    duration { "" }
+    duration { "180" }
     date { "2023-01-30 19:47:54" }
     start_time { "2023-01-30 19:47:54" }
-    movie_id { nil }
+    movie_id { 14 }
     host { create(:user) }
   end
 end

--- a/spec/features/users/viewing_parties/new_spec.rb
+++ b/spec/features/users/viewing_parties/new_spec.rb
@@ -43,14 +43,51 @@ RSpec.describe 'New Viewing Party Page' do
         page.check(@user2.display_name)
         page.check(@user3.display_name)
         click_button "Create Party"
-  
-        expect(current_path).to eq(user_path(@user.id))
       end
+
+      expect(current_path).to eq(user_path(@user.id))
     end
   end
 
   describe 'New viewing party form - sad path' do 
+    it 'should not create a new viewing party if the form is not completely filled out' do 
+      user1 = User.create(name: "River", email: "river@example.com")
+      user2 = User.create(name: "Bodi", email: "bodi@example.com")
+      user3 = User.create(name: "Dean", email: "dean@example.com")
 
+      within(".new_viewing_party_form") do 
+        expect(page).to have_field("Movie Title", with: "American Beauty", disabled: true)
+
+        fill_in("Duration of Party", with: 10)
+        select("2025", from: "[date(1i)]")
+        select("March", from: "[date(2i)]")
+        select("5", from: "[date(3i)]")
+        select("20", from: "[start_time(4i)]")
+        select("00", from: "[start_time(5i)]")
+        page.check(@user2.display_name)
+        page.check(@user3.display_name)
+        click_button "Create Party"
+      end
+
+      expect(current_path).to eq(new_user_movie_viewing_party_path(@user.id, @movie_id))
+      expect(page).to have_content("Viewing Party duration must be greater than or equal to movie runtime which is 122")
+
+      within(".new_viewing_party_form") do 
+        expect(page).to have_field("Movie Title", with: "American Beauty", disabled: true)
+
+        fill_in("Duration of Party", with: "")
+        select("2025", from: "[date(1i)]")
+        select("March", from: "[date(2i)]")
+        select("5", from: "[date(3i)]")
+        select("20", from: "[start_time(4i)]")
+        select("00", from: "[start_time(5i)]")
+        page.check(@user2.display_name)
+        page.check(@user3.display_name)
+        click_button "Create Party"
+      end
+
+      expect(current_path).to eq(new_user_movie_viewing_party_path(@user.id, @movie_id))
+      expect(page).to have_content("Viewing Party duration must be greater than or equal to movie runtime which is 122")
+    end
   end
-
 end

--- a/spec/features/users/viewing_parties/new_spec.rb
+++ b/spec/features/users/viewing_parties/new_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'New Viewing Party Page' do
     visit new_user_movie_viewing_party_path(@user.id, @movie_id)
   end
   
-  describe 'navigation' do 
+  describe 'page layout' do 
     it 'should have a discover page button' do 
       visit user_movies_path(@user)
 
@@ -15,12 +15,26 @@ RSpec.describe 'New Viewing Party Page' do
 
       expect(current_path).to eq(discover_user_path(@user))
     end
-  end
 
-  describe 'New viewing party form' do 
     it 'displays the movie that user is creating a party for' do 
 
       expect(page).to have_content("Create a Movie Party for American Beauty")
     end
   end
+
+  describe 'New viewing party form - happy path' do 
+    it 'has a form to create a viewing party' do 
+
+      within(".new_viewing_party_form") do 
+        expect(page).to have_field("Movie Title", with: "American Beauty", disabled: true)
+        # fill_in("Duration of Party", with: 180)
+        # select("2/2/2025", from: "Day")
+      end
+    end
+  end
+
+  describe 'New viewing party form - sad path' do 
+
+  end
+
 end

--- a/spec/features/users/viewing_parties/new_spec.rb
+++ b/spec/features/users/viewing_parties/new_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'New Viewing Party Page' do 
+  before :each do 
+    @user = create(:user)
+    @movie_id = 14
+    visit new_user_movie_viewing_party_path(@user.id, @movie_id)
+  end
+  
+  describe 'navigation' do 
+    it 'should have a discover page button' do 
+      visit user_movies_path(@user)
+
+      click_button "Discover Page"
+
+      expect(current_path).to eq(discover_user_path(@user))
+    end
+  end
+
+  describe 'New viewing party form' do 
+    it 'displays the movie that user is creating a party for' do 
+
+      expect(page).to have_content("Create a Movie Party for American Beauty")
+    end
+  end
+end

--- a/spec/features/users/viewing_parties/new_spec.rb
+++ b/spec/features/users/viewing_parties/new_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe 'New Viewing Party Page' do
   before :each do 
     @user = create(:user)
     @movie_id = 14
+    @user2 = User.create(name: "River", email: "river@example.com")
+    @user3 = User.create(name: "Bodi", email: "bodi@example.com")
+    @user4 = User.create(name: "Dean", email: "dean@example.com")
     visit new_user_movie_viewing_party_path(@user.id, @movie_id)
   end
   
@@ -24,11 +27,24 @@ RSpec.describe 'New Viewing Party Page' do
 
   describe 'New viewing party form - happy path' do 
     it 'has a form to create a viewing party' do 
+      user1 = User.create(name: "River", email: "river@example.com")
+      user2 = User.create(name: "Bodi", email: "bodi@example.com")
+      user3 = User.create(name: "Dean", email: "dean@example.com")
 
       within(".new_viewing_party_form") do 
         expect(page).to have_field("Movie Title", with: "American Beauty", disabled: true)
-        # fill_in("Duration of Party", with: 180)
-        # select("2/2/2025", from: "Day")
+
+        fill_in("Duration of Party", with: 180)
+        select("2025", from: "[date(1i)]")
+        select("March", from: "[date(2i)]")
+        select("5", from: "[date(3i)]")
+        select("20", from: "[start_time(4i)]")
+        select("00", from: "[start_time(5i)]")
+        page.check(@user2.display_name)
+        page.check(@user3.display_name)
+        click_button "Create Party"
+  
+        expect(current_path).to eq(user_path(@user.id))
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,4 +12,12 @@ RSpec.describe User, type: :model do
     it { should validate_presence_of :email}
     it { should validate_uniqueness_of :email}
   end
+
+  describe 'model tests' do 
+    it 'returns the users name and email' do 
+      user = User.create(name: "River", email: "river@gmail.com")
+
+      expect(user.display_name).to eq("River (river@gmail.com)")
+    end
+  end
 end

--- a/spec/models/viewing_party_spec.rb
+++ b/spec/models/viewing_party_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe ViewingParty, type: :model do
     it { should have_many(:users).through(:viewing_party_users) }
   end
 
+  describe 'validations' do 
+    it { should validate_presence_of :duration }
+    it { should validate_presence_of :date }
+    it { should validate_presence_of :start_time }
+    it { should validate_presence_of :movie_id }
+  end
+
   describe '#movie' do
     it 'returns a movie object' do
       vp = create(:viewing_party, movie_id: 14)


### PR DESCRIPTION
###Issue number, if any: 
  New Viewing Party Page
  

###Summary of what changed and why: 
- Create form to create a new viewing party page that includes, duration, date, time, checkboxes for existing users
- A viewing party cannot be created if the party duration is less than the movie duration

###Known Issues:
Question - has a test been written to test that the new viewing party is listed on other user's dashboards if they were invited (not just the host's dashboard)?


###Reviewers:
@Tscasady 

