### PR TITLE
Fix/movie link

### DIFF
--- a/app/views/users/_viewing_party.html.erb
+++ b/app/views/users/_viewing_party.html.erb
@@ -1,20 +1,21 @@
-<div id=<%= "#{party_type}_#{viewing_party.id}"%>> <p>Movie Title: <%= link_to viewing_party.movie.title, user_movies_path(@user) %></p>
+<div id=<%= "#{party_type}_#{viewing_party.id}"%>> 
+  <p>Movie Title: <%= link_to viewing_party.movie.title, user_movie_path(@user, viewing_party.movie.id) %></p>
   <div id="movie-poster">
     <p><%= image_tag viewing_party.movie.image_path %></p>
   </div>
-<p>Date of Event: <%= viewing_party.date %></p>
-<p>Start Time: <%= viewing_party.start_time %></p>
-<% if @user != viewing_party.host %>
-  <p>Host: <%= viewing_party.host.name %></p>
-<% else %>
-  <p>You are the host of this viewing party.</p>
-<% end %>
-<p>Invited: </p>
-<% viewing_party.users.each do |user| %>
-  <% if @user.name == user.name  %>
-    <b><%= user.name %></b>
+  <p>Date of Event: <%= viewing_party.date %></p>
+  <p>Start Time: <%= viewing_party.start_time %></p>
+  <% if @user != viewing_party.host %>
+    <p>Host: <%= viewing_party.host.name %></p>
   <% else %>
-    <%= user.name %>
+    <p>You are the host of this viewing party.</p>
   <% end %>
-<% end %>
+  <p>Invited: </p>
+  <% viewing_party.users.each do |user| %>
+    <% if @user.name == user.name  %>
+      <b><%= user.name %></b>
+    <% else %>
+      <%= user.name %>
+    <% end %>
+  <% end %>
 </div>

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe 'The User Dashboard page', type: :feature do
         invited_parties = user.invited_parties
         within "#invited_parties" do
           invited_parties.each do |party|
-#            src = party.movie.image_path
             within "#invited_#{party.id}" do
               expect(page).to have_content "Movie Title: #{party.movie.title}"
               expect(page).to have_link "#{party.movie.title}"
@@ -57,7 +56,6 @@ RSpec.describe 'The User Dashboard page', type: :feature do
 
       it 'lists all viewing parties the user has hosted' do
         hosted_parties = user.hosted_parties
-        save_and_open_page
         within "#hosted_parties" do
           hosted_parties.each do |party|
             within "#hosted_#{party.id}" do
@@ -73,6 +71,13 @@ RSpec.describe 'The User Dashboard page', type: :feature do
             end
           end
         end
+      end
+
+      it 'the movies links go to the movie details page' do
+        sample_party = user.invited_parties.first
+        click_link "#{sample_party.movie.title}"
+
+        expect(current_path).to eq user_movie_path(user, sample_party.movie.id)
       end
     end
   end


### PR DESCRIPTION
###Issue number, if any: 
  None

###Summary of what changed and why: 
Link on user dashboard routed to user/id/movies instead of user/id/movie/id

###Known Issues: 
None

###Reviewers: 
@KelsiePorter 
