### PR TITLE
Implement structs instead of manipulating raw hashes in movie_show.

### DIFF
--- a/app/poros/movie.rb
+++ b/app/poros/movie.rb
@@ -4,8 +4,6 @@ class Movie
               :vote_average,
               :runtime,
               :overview,
-              :cast,
-              :reviews,
               :image_path
 
   def initialize(movie_params)
@@ -20,7 +18,6 @@ class Movie
     @image_path = base_image_uri + movie_params[:poster_path]
   end
 
-  # TODO: Consider Cast and Review poros
 
   def genres
     @genres.map do |genre|
@@ -30,6 +27,24 @@ class Movie
 
   def review_total
     @reviews.length
+  end
+
+  def cast
+    @cast.map do |cast_member|
+      actor = OpenStruct.new
+      actor.name = cast_member[:name]
+      actor.character = cast_member[:character]
+      actor
+    end
+  end
+
+  def reviews
+    @reviews.map do |review|
+      critic = OpenStruct.new
+      critic.author = review[:author]
+      critic.content = review[:content]
+      critic
+    end
   end
 
   private 

--- a/app/views/users/movies/show.html.erb
+++ b/app/views/users/movies/show.html.erb
@@ -18,16 +18,16 @@
   <h4>Cast</h4>
   <div id="cast">
     <% @movie.cast.each do |cast_member| %>
-      <%= "Actor: #{cast_member[:name]}, " %>
-      <%= "Character: #{cast_member[:character]}" %>
+      <%= "Actor: #{cast_member.name}, " %>
+      <%= "Character: #{cast_member.character}" %>
       <br>
     <% end %>
   </div>
   <div id="reviews">
     <h4><%= @movie.review_total %> Reviews</h4>
     <% @movie.reviews.each do |review| %>
-      <p><%= "Review Author: #{review[:author]}"%></p>
-      <p><%= "Review: #{review[:content]}" %></p>
+      <p><%= "Review Author: #{review.author}"%></p>
+      <p><%= "Review: #{review.content}" %></p>
     <% end %>
   </div>
 </div>

--- a/spec/poros/movie_spec.rb
+++ b/spec/poros/movie_spec.rb
@@ -14,8 +14,6 @@ RSpec.describe Movie do
       expect(movie.runtime).to eq 120
       expect(movie.genres).to eq "Drama, Action" 
       expect(movie.overview).to eq "a film depicting a story"
-      #expect(movie.cast).to be_a  
-      #expect(movie.reviews).to eq [{ author: 'reviewer', review: 'good' }, { author: 'other reviewer', review: 'not the best' }]
       expect(movie.image_path).to eq "https://image.tmdb.org/t/p/w500/imagelocation"
     end
   end
@@ -30,6 +28,26 @@ RSpec.describe Movie do
   describe '#review_total' do
     it 'returns the total number of reviews a movie has' do
       expect(movie.review_total).to eq 2
+    end
+  end
+
+  describe '#cast' do
+    it 'creates an Array of Structs containt cast data' do
+      expect(movie.cast).to be_a Array
+      movie.cast.each do |cast_member|
+        expect(cast_member).to be_a OpenStruct
+      end
+      expect(movie.cast.first.name).to eq 'actor'
+    end
+  end
+
+  describe '#review' do
+    it 'creates an Array of Structs containing review data' do
+      expect(movie.reviews).to be_a Array
+      movie.reviews.each do |review|
+        expect(review).to be_a OpenStruct
+      end
+      expect(movie.reviews.first.author).to eq 'reviewer'
     end
   end
 end


### PR DESCRIPTION
###Issue number, if any: 
  None
 
###Summary of what changed and why: 
Uses openstructs instead of raw hash manipulation for movie show page when displaying cast and reviewer data.

###Known Issues: None
###Reviewers: @KelsiePorter 
